### PR TITLE
Allow to set a default role which applies when a user without roles logs in using Keyrock

### DIFF
--- a/config.js
+++ b/config.js
@@ -437,7 +437,7 @@ config.indexes.elasticHost = process.env.BAE_LP_INDEX_URL || config.indexes.elas
 config.indexes.apiVersion = process.env.BAE_LP_INDEX_API_VERSION || config.indexes.apiVersion;
 
 // External IDPs configs
-if (config.extLogin && process.env.BAE_EXT_IDPS_CONF != null) {
+if (config.extLogin) {
     config.localEORI = process.env.BAE_EORI;
     config.ishareKey = process.env.BAE_TOKEN_KEY;
     config.ishareCrt = process.env.BAE_TOKEN_CRT;

--- a/config.js
+++ b/config.js
@@ -41,9 +41,9 @@ config.oauth2 = {
     oidc: true,
     oidcScopes: "openid",
     oidcDiscoveryURI: null,
-    oidcDefaultRole: null,
     oidcTokenEndpointAuthMethod: "client_secret_basic",
     key: '281e126aa35c80f2',
+    defaultRole: null,
     roles: {
         admin: 'admin',
         customer: 'customer',
@@ -270,6 +270,10 @@ config.oauth2.clientID = process.env.BAE_LP_OAUTH2_CLIENT_ID || config.oauth2.cl
 config.oauth2.clientSecret = process.env.BAE_LP_OAUTH2_CLIENT_SECRET || config.oauth2.clientSecret;
 config.oauth2.callbackURL = process.env.BAE_LP_OAUTH2_CALLBACK || config.oauth2.callbackURL;
 
+if (process.env.BAE_LP_OAUTH2_DEFAULT_ROLE) {
+    config.oauth2.defaultRole = process.env.BAE_LP_OAUTH2_DEFAULT_ROLE;
+}
+
 if (!!process.env.BAE_LP_OIDC_ENABLED) {
     config.oauth2.oidc = process.env.BAE_LP_OIDC_ENABLED == 'true';
 }
@@ -278,9 +282,6 @@ config.oauth2.oidcScopes = process.env.BAE_LP_OIDC_SCOPES || config.oauth2.oidcS
 config.oauth2.oidcTokenEndpointAuthMethod = process.env.BAE_LP_OIDC_TOKEN_AUTH_METHOD || config.oauth2.oidcTokenEndpointAuthMethod;
 if (process.env.BAE_LP_OIDC_DISCOVERY_URI) {
     config.oauth2.oidcDiscoveryURI = process.env.BAE_LP_OIDC_DISCOVERY_URI;
-}
-if (process.env.BAE_LP_OIDC_DEFAULT_ROLE) {
-    config.oauth2.oidcDefaultRole = process.env.BAE_LP_OIDC_DEFAULT_ROLE;
 }
 
 config.oauth2.key = process.env.BAE_LP_OIDC_KEY || config.oauth2.key;

--- a/lib/strategies/fiware.js
+++ b/lib/strategies/fiware.js
@@ -39,6 +39,14 @@ function strategy (config) {
         if (!profile.displayName && !profile._json.displayName) {
             profile.displayName = profile.username;
         }
+
+	// Default role
+	if ((!profile.roles || profile.roles === undefined || profile.roles.length == 0) && config.defaultRole) {
+	    profile.roles = [{
+		'name': config.defaultRole,
+		'id': config.defaultRole
+	    }];
+	}
     }
 
     async function buildStrategy(callback) {

--- a/lib/strategies/oidc-discover.js
+++ b/lib/strategies/oidc-discover.js
@@ -58,10 +58,10 @@ function strategy (config) {
 
 	// Roles
 	if (!profile.roles) {
-	    if (config.oidcDefaultRole) {
+	    if (config.defaultRole) {
 		profile.roles = [{
-		    'name': config.oidcDefaultRole,
-		    'id': config.oidcDefaultRole
+		    'name': config.defaultRole,
+		    'id': config.defaultRole
 		}];
 	    } else {
 		profile.roles = [{

--- a/server.js
+++ b/server.js
@@ -218,8 +218,8 @@ let idps = {
     'local': auth
 };
 
-const addIdpStrategy = (idp) => {
-    let extAuth = authModule.auth(idp);
+const addIdpStrategy = async (idp) => {
+    let extAuth = await authModule.auth(idp);
     passport.use(idp.idpId, extAuth.STRATEGY);
 
     // Handler for default logging
@@ -250,11 +250,11 @@ if (extLogin) {
     // Load IDPs from database
     const externalIdps = await idpService.getDBIdps();
 
-    externalIdps.forEach((idp) => {
+    externalIdps.forEach(async (idp) => {
         console.log("===========================");
         console.log(idp);
 
-        const extAuth = addIdpStrategy(idp);
+        const extAuth = await addIdpStrategy(idp);
         //authMiddleware.addIdp(idp, extAuth);
         idps[idp.idpId] = extAuth;
     });
@@ -340,8 +340,8 @@ app.post(config.reputationServicePath + '/reputation/set', reputationService.sav
 /////////////////////////////////////////////////////////////////////
 
 if (extLogin) {
-    const setNewIdp = function(idp) {
-        const extAuth = addIdpStrategy(idp);
+    const setNewIdp = async function(idp) {
+        const extAuth = await addIdpStrategy(idp);
         authMiddleware.addIdp(idp.idpId, extAuth);
     }
 

--- a/test/lib/strategies/fiware.js
+++ b/test/lib/strategies/fiware.js
@@ -162,6 +162,65 @@ describe('Keyrock Strategy', () => {
 
             userStrategy.loginComplete();
         });
+
+	it('should create FIWARE strategy with default role set and without OIDC', async (done) => {
+	    const passportMock = {
+                OAuth2Strategy: MockStrategy
+            }
+
+            const toTest = buildStrategyMock(passportMock);
+	    
+	    // Test the strategy builder
+            const config = {
+                clientID: 'client_id',
+                clientSecret: 'client_secret',
+                callbackURL: 'http://maket.com/callback',
+                server: 'http://ipd.com',
+                oidc: false,
+                defaultRole: "seller"
+            }
+            const builderToTest = toTest(config);
+	    const userStrategy = await builderToTest.buildStrategy((accessToken, refreshToken, profile, cbDone) => {
+                // Callback configured to be called when the strategy succeeds in the login
+                // Check that the callback is properly configured
+                expect(accessToken).toEqual('token');
+                expect(refreshToken).toEqual('refresh');
+                expect(profile).toEqual({
+                    expire: 12345678,
+                    username: 'username',
+                    displayName: 'display name',
+                    _json: {
+                        exp: 12345678,
+                        username: 'username',
+                        displayName: 'display name',
+                    },
+		    roles: [{
+			name: "seller",
+			id: "seller"
+		    }]
+                });
+
+		let params = userStrategy.getParams();
+                expect(params).toEqual({
+                    clientID: 'client_id',
+                    clientSecret: 'client_secret',
+                    callbackURL: 'http://maket.com/callback',
+                    serverURL: 'http://ipd.com'
+                });
+                done();
+            });
+
+	    userStrategy.setProfileParams(null, {
+                _json: {
+                    exp: 12345678,
+                    username: 'username',
+                    displayName: 'display name',
+                }
+            }, 'token', 'refresh');
+
+            userStrategy.loginComplete();
+	    
+	});
     });
 
     describe('Get Scope', () => {

--- a/test/lib/strategies/oidc-discover.js
+++ b/test/lib/strategies/oidc-discover.js
@@ -1,0 +1,80 @@
+/* Copyright (c) 2021 Future Internet Consulting and Development Solutions S.L.
+ *
+ * This file belongs to the business-ecosystem-logic-proxy of the
+ * Business API Ecosystem
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const proxyquire = require('proxyquire');
+
+describe('OIDC-Discover Strategy', () => {
+
+    const MockStrategy = function MockStrategy(params, cb) {
+        this.params = params;
+        this.cb = cb;
+    }
+    MockStrategy.prototype.setProfileParams = function(err, profile, token, refreshToken) {
+        this.userErr = err;
+        this.profile = profile;
+        this.token = token;
+        this.refreshToken = refreshToken;
+    }
+    MockStrategy.prototype.userProfile = function(token, done) {
+        this.token = token;
+        done(this.userErr, this.profile);
+    }
+    MockStrategy.prototype.loginComplete = function() {
+        this.cb(this.token, this.refreshToken, this.profile, 'cb');
+    }
+    MockStrategy.prototype.getParams = function () {
+        return this.params;
+    }
+
+    const buildStrategyMock = function buildStrategyMock(passport) {
+        return proxyquire('../../../lib/strategies/oidc-discover', {
+            'openid-client': passport,
+        }).strategy;
+    }
+
+    describe('Build Strategy', () => {
+	
+	it('should create strategy', async (done) => {
+	    
+            const passportMock = {
+                OAuth2Strategy: MockStrategy
+            }
+
+            const toTest = buildStrategyMock(passportMock);
+
+            // Test the strategy builder
+            const config = {
+                clientID: 'client_id',
+                clientSecret: 'client_secret',
+                callbackURL: 'http://maket.com/callback',
+                server: 'http://ipd.com',
+                oidcScopes: "openid",
+		oidcDiscoveryURI: 'http://ipd.com/.well-known/openid-configuration',
+		oidcTokenEndpointAuthMethod: "client_secret_basic",
+		defaultRole: "seller",
+		key: "key"
+            }
+            const builderToTest = toTest(config);
+
+	});
+
+	
+    });
+    
+});


### PR DESCRIPTION
* Set via ENV: BAE_LP_OAUTH2_DEFAULT_ROLE
* When ENV is not set, there will be no default role applied to the user (behaviour as before)
* Same ENV is also used now for the default role with oidc-discover strategy