### PR TITLE
fix/oid-vc: Add DSP enable flag and fix OpenID Connect VC support

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,7 +43,8 @@ config.oauth2 = {
 	oidcDiscoveryURI: null,
 	oidcTokenEndpointAuthMethod: "client_secret_basic",
 	key: '281e126aa35c80f2',
-	defaultRole: null
+	defaultRole: null,
+    nonce: false
 };
 
 config.roles = {
@@ -409,6 +410,10 @@ config.oauth2.server = process.env.BAE_LP_OAUTH2_SERVER || config.oauth2.server;
 config.oauth2.clientID = process.env.BAE_LP_OAUTH2_CLIENT_ID || config.oauth2.clientID;
 config.oauth2.clientSecret = process.env.BAE_LP_OAUTH2_CLIENT_SECRET || config.oauth2.clientSecret;
 config.oauth2.callbackURL = process.env.BAE_LP_OAUTH2_CALLBACK || config.oauth2.callbackURL;
+
+if (!!process.env.BAE_LP_OAUTH2_NONCE) {
+    config.oauth2.nonce = process.env.BAE_LP_OAUTH2_NONCE == 'true'
+}
 
 if (process.env.BAE_LP_OAUTH2_DEFAULT_ROLE) {
     config.oauth2.defaultRole = process.env.BAE_LP_OAUTH2_DEFAULT_ROLE;

--- a/config.js
+++ b/config.js
@@ -778,6 +778,10 @@ if (!!process.env.BAE_LP_DATASPACE_ENABLED) {
     config.dataSpaceEnabled = process.env.BAE_LP_DATASPACE_ENABLED == 'true';
 }
 
+config.dspEnabled = false
+if (!!process.env.BAE_LP_DSP_ENABLED) {
+    config.dspEnabled = process.env.BAE_LP_DSP_ENABLED == 'true';
+}
 config.launchValidationEnabled = false;
 if (!!process.env.BAE_LP_LAUNCH_VALIDATION_ENABLED) {
     config.launchValidationEnabled = process.env.BAE_LP_LAUNCH_VALIDATION_ENABLED == 'true';

--- a/lib/strategies/oidc-discover.js
+++ b/lib/strategies/oidc-discover.js
@@ -119,6 +119,16 @@ function strategy (config) {
 			done(err);
 		});
 	}
+
+	userStrategy.refresh = function(refreshToken, done) {
+		client.refresh(refreshToken).then((tokenSet) => {
+			done(null, tokenSet.access_token, tokenSet.refresh_token);
+		}).catch((err) => {
+			logger.debug('Failed to refresh token', err);
+			done(err);
+		});
+	}
+
 	return userStrategy;
 
     }

--- a/lib/strategies/oidc-discover.js
+++ b/lib/strategies/oidc-discover.js
@@ -17,13 +17,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { Issuer, Strategy } = require('openid-client');
+const { Issuer, Strategy, generators } = require('openid-client');
+const { createRemoteJWKSet, jwtVerify } = require('jose');
 const nodeConfig = require('../../config');
+const { VerifiableCredential } = require('./passport-vc');
+const { logger } = require('../logger').logger.getLogger('Auth');
 
 function strategy (config) {
 
     function buildProfile(profile) {
 
+	// try to build from vc
+	try {
+		const vc = new VerifiableCredential(profile);
+		return vc.getProfile();
+	} catch (error) {
+		logger.debug(`Profile is not a VC ${profile}`, error)
+	}
 	// Set ID
 	if (!profile.id) {
 	    if (profile.sub) {
@@ -70,6 +80,7 @@ function strategy (config) {
 		}];
 	    }
 	}
+	return profile;
     }
 
     async function buildStrategy(callback) {
@@ -89,25 +100,38 @@ function strategy (config) {
 	});
 
 	// Create strategy
-	const userStrategy = new Strategy({ client }, (tokenSet, userinfo, done) => {
-	    buildProfile(userinfo);
-
-	    return callback(tokenSet.access_token, tokenSet.refresh_token, userinfo, done);
+	const params = {}
+	if (nodeConfig.oauth2.nonce) {
+		params.nonce = generators.nonce()
+	}
+	const userStrategy = new Strategy({ client, params }, (tokenSet, done) => {
+	    const profile = buildProfile(tokenSet.claims());
+	    return callback(tokenSet.access_token, tokenSet.refresh_token, profile, done);
 	});
-	
+
+	userStrategy.userProfile = function(accessToken, done) {
+		const JWKS = createRemoteJWKSet(new URL(client.issuer.metadata.jwks_uri));
+		jwtVerify(accessToken, JWKS, { issuer: client.issuer.issuer }).then(({ payload }) => {
+			const profile = buildProfile(payload);
+			done(null, profile);
+		}).catch((err) => {
+			logger.debug('Failed to verify access token signature', err);
+			done(err);
+		});
+	}
 	return userStrategy;
-        		
+
     }
 
     function getScope() {
 	return config.oidcScopes;
     }
-    
+
     return {
         buildStrategy: buildStrategy,
         getScope: getScope
     }
-    
+
 }
 
 exports.strategy = strategy;

--- a/lib/strategies/oidc-discover.js
+++ b/lib/strategies/oidc-discover.js
@@ -21,7 +21,7 @@ const { Issuer, Strategy, generators } = require('openid-client');
 const { createRemoteJWKSet, jwtVerify } = require('jose');
 const nodeConfig = require('../../config');
 const { VerifiableCredential } = require('./passport-vc');
-const { logger } = require('../logger').logger.getLogger('Auth');
+const logger = require('../logger').logger.getLogger('Auth');
 
 function strategy (config) {
 

--- a/lib/strategies/passport-vc.js
+++ b/lib/strategies/passport-vc.js
@@ -299,6 +299,7 @@ class VerifiableCredential {
         profile._json = this.payload;
 
         profile.organizations = [this.credentialSubject.organization]
+        profile.expire = this.payload.exp;
         return profile;
     }
 }

--- a/lib/strategies/passport-vc.js
+++ b/lib/strategies/passport-vc.js
@@ -261,8 +261,9 @@ class VerifiableCredential {
             this.issuer = data.issuer;
             this.payload = payload;
         }
-
-        if (payload.hasOwnProperty('verifiableCredential')) {
+        if (payload.hasOwnProperty('credentialSubject')) {
+            processSubject(payload);
+        } else if (payload.hasOwnProperty('verifiableCredential')) {
             const data = payload['verifiableCredential'];
             processSubject(data)
         } else if (payload.hasOwnProperty('vc')) {

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ const editParty = config.editParty == true;
 
 // Local auth method
 const auth = await authModule.auth(config.oauth2);
-    
+
 /////////////////////////////////////////////////////////////////////
 ////////////////////////// MONGOOSE CONFIG //////////////////////////
 /////////////////////////////////////////////////////////////////////
@@ -344,7 +344,7 @@ app.all(config.logOutPath, function(req, res) {
 });
 
 // Config endpoint
-const fetchData = async () => { 
+const fetchData = async () => {
     result = await indexes.search('defaultcatalog', {})
     return (result.length === 0 || result.length > 1)? '' : result[0].default_id
 }
@@ -452,6 +452,7 @@ app.get('/config', async (_, res) => {
         domePublish: config.domePublish,
         purchaseEnabled: config.purchaseEnabled,
         dataSpaceEnabled: config.dataSpaceEnabled,
+        dspEnabled: config.dspEnabled,
         quoteApi: config.quoteApi,
         defaultId: config.defaultId,
         paymentGateway: config.paymentGateway,

--- a/test/lib/strategies/oidc-discover.js
+++ b/test/lib/strategies/oidc-discover.js
@@ -308,6 +308,79 @@ describe('OIDC-Discover Strategy', () => {
 	    });
 	});
 
+	describe('refresh token', () => {
+	    let userStrategy;
+	    let mockRefresh;
+
+	    beforeEach(async () => {
+		mockRefresh = jasmine.createSpy('refresh');
+
+		const discoverWithRefresh = async function(uri) {
+		    const clientConstructor = function(opts) {
+			return {
+			    discovery_uri: uri,
+			    client_id: opts.client_id,
+			    client_secret: opts.client_secret,
+			    redirect_uris: opts.redirect_uris,
+			    token_endpoint_auth_method: opts.token_endpoint_auth_method,
+			    refresh: mockRefresh
+			};
+		    };
+		    return { Client: clientConstructor };
+		};
+
+		const passportMock = {
+		    Issuer: { discover: discoverWithRefresh },
+		    Strategy: MockStrategy
+		};
+
+		const config = {
+		    clientID: 'client_id',
+		    clientSecret: 'client_secret',
+		    callbackURL: 'http://market.com/callback',
+		    server: 'http://idp.com',
+		    oidcScopes: 'openid',
+		    oidcDiscoveryURI: 'http://idp.com/.well-known/openid-configuration',
+		    oidcTokenEndpointAuthMethod: 'client_secret_basic',
+		    defaultRole: 'seller',
+		    key: 'key'
+		};
+
+		const toTest = buildStrategyMock(passportMock);
+		const builderToTest = toTest(config);
+		userStrategy = await builderToTest.buildStrategy(() => {});
+	    });
+
+	    it('should call done with new tokens on successful refresh', async () => {
+		mockRefresh.and.returnValue(Promise.resolve({
+		    access_token: 'new-access-token',
+		    refresh_token: 'new-refresh-token'
+		}));
+
+		await new Promise((resolve) => {
+		    userStrategy.refresh('old-refresh-token', (err, accessToken, refreshToken) => {
+			expect(err).toBeNull();
+			expect(accessToken).toEqual('new-access-token');
+			expect(refreshToken).toEqual('new-refresh-token');
+			expect(mockRefresh).toHaveBeenCalledWith('old-refresh-token');
+			resolve();
+		    });
+		});
+	    });
+
+	    it('should call done with error on failed refresh', async () => {
+		const refreshError = new Error('token refresh failed');
+		mockRefresh.and.returnValue(Promise.reject(refreshError));
+
+		await new Promise((resolve) => {
+		    userStrategy.refresh('invalid-refresh-token', (err) => {
+			expect(err).toEqual(refreshError);
+			resolve();
+		    });
+		});
+	    });
+	});
+
 	it('should return specified scope', () => {
             const passportMock = {
 		Issuer: MockIssuer,

--- a/test/lib/strategies/oidc-discover.js
+++ b/test/lib/strategies/oidc-discover.js
@@ -37,7 +37,13 @@ describe('OIDC-Discover Strategy', () => {
         done(this.userErr, this.profile);
     }
     MockStrategy.prototype.loginComplete = function() {
-        this.cb({access_token: this.token, refresh_token: this.refreshToken}, this.profile, 'cb');
+        const profile = this.profile;
+        const tokenSet = {
+            access_token: this.token,
+            refresh_token: this.refreshToken,
+            claims: () => profile
+        };
+        this.cb(tokenSet, 'cb');
     }
     MockStrategy.prototype.getClient = function () {
         return this.client;
@@ -126,6 +132,180 @@ describe('OIDC-Discover Strategy', () => {
 
             userStrategy.loginComplete();
 	    
+	});
+
+	describe('VerifiableCredential profiles', () => {
+
+	    let builderToTest;
+
+	    beforeEach(async () => {
+		const passportMock = {
+		    Issuer: MockIssuer,
+		    Strategy: MockStrategy
+		};
+		const config = {
+		    clientID: 'client_id',
+		    clientSecret: 'client_secret',
+		    callbackURL: 'http://market.com/callback',
+		    server: 'http://idp.com',
+		    oidcScopes: 'openid',
+		    oidcDiscoveryURI: 'http://idp.com/.well-known/openid-configuration',
+		    oidcTokenEndpointAuthMethod: 'client_secret_basic',
+		    defaultRole: 'seller',
+		    key: 'key'
+		};
+		const toTest = buildStrategyMock(passportMock);
+		builderToTest = toTest(config);
+	    });
+
+	    it('should build profile from plain VC credentialSubject', async () => {
+		const vcClaims = {
+		    type: ['VerifiableCredential'],
+		    issuer: 'did:example:issuer',
+		    credentialSubject: {
+			email: 'user@example.com',
+			firstName: 'John',
+			familyName: 'Doe',
+			roles: [{ names: ['seller'] }]
+		    }
+		};
+
+		const userStrategy = await builderToTest.buildStrategy((accessToken, refreshToken, profile, cbDone) => {
+		    expect(accessToken).toEqual('vc-token');
+		    expect(refreshToken).toEqual('vc-refresh');
+		    expect(profile.id).toEqual('user@example.com');
+		    expect(profile.email).toEqual('user@example.com');
+		    expect(profile.username).toEqual('user');
+		    expect(profile.displayName).toEqual('John Doe');
+		    expect(profile.roles).toEqual([{ id: 'seller', name: 'seller' }]);
+		    expect(profile.issuerDid).toEqual('did:example:issuer');
+		    expect(profile.idpId).toEqual('did:example:issuer');
+		    expect(profile._json).toEqual(vcClaims);
+		    expect(profile.organizations).toEqual([{
+			id: 'did:example:issuer',
+			name: 'did:example:issuer',
+			roles: [
+			    { name: 'Seller', id: 'Seller' },
+			    { name: 'Buyer', id: 'Buyer' },
+			    { name: 'orgAdmin', id: 'orgAdmin' }
+			]
+		    }]);
+		});
+
+		userStrategy.setProfileParams(null, vcClaims, 'vc-token', 'vc-refresh');
+		userStrategy.loginComplete();
+	    });
+
+	    it('should build profile from LEARCredentialEmployee vc field', async () => {
+		const vcClaims = {
+		    sub: 'did:user:123',
+		    vc: {
+			type: ['VerifiableCredential', 'LEARCredentialEmployee'],
+			issuer: 'did:issuer:123',
+			credentialSubject: {
+			    mandate: {
+				mandatee: {
+				    id: 'did:user:123',
+				    email: 'john.doe@example.com',
+				    first_name: 'John',
+				    last_name: 'Doe'
+				},
+				mandator: {
+				    organizationIdentifier: 'org-123',
+				    organization: 'Test Org'
+				},
+				power: [{
+				    tmf_function: 'productOffering',
+				    tmf_action: ['create', 'update']
+				}]
+			    }
+			}
+		    }
+		};
+
+		const userStrategy = await builderToTest.buildStrategy((accessToken, refreshToken, profile, cbDone) => {
+		    expect(accessToken).toEqual('lear-token');
+		    expect(refreshToken).toEqual('lear-refresh');
+		    expect(profile.id).toEqual('did:user:123');
+		    expect(profile.email).toEqual('john.doe@example.com');
+		    expect(profile.username).toEqual('john.doe');
+		    expect(profile.displayName).toEqual('John Doe');
+		    expect(profile.issuerDid).toEqual('did:issuer:123');
+		    expect(profile.idpId).toEqual('did:issuer:123');
+		    expect(profile._json).toEqual(vcClaims);
+		    expect(profile.organizations).toEqual([{
+			id: 'org-123',
+			name: 'Test Org',
+			roles: [{ id: 'Seller', name: 'Seller' }]
+		    }]);
+		});
+
+		userStrategy.setProfileParams(null, vcClaims, 'lear-token', 'lear-refresh');
+		userStrategy.loginComplete();
+	    });
+
+	    it('should build profile from LEARCredentialEmployee verifiableCredential field', async () => {
+		const vcClaims = {
+		    sub: 'did:user:456',
+		    verifiableCredential: {
+			type: ['VerifiableCredential', 'LEARCredentialEmployee'],
+			issuer: 'did:issuer:456',
+			credentialSubject: {
+			    mandate: {
+				mandatee: {
+				    id: 'did:user:456',
+				    email: 'jane.smith@example.com',
+				    first_name: 'Jane',
+				    last_name: 'Smith'
+				},
+				mandator: {
+				    organizationIdentifier: 'org-456',
+				    organization: 'Other Org'
+				},
+				power: [{
+				    tmf_function: 'Onboarding',
+				    tmf_action: 'execute'
+				}]
+			    }
+			}
+		    }
+		};
+
+		const userStrategy = await builderToTest.buildStrategy((accessToken, refreshToken, profile, cbDone) => {
+		    expect(profile.id).toEqual('did:user:456');
+		    expect(profile.email).toEqual('jane.smith@example.com');
+		    expect(profile.username).toEqual('jane.smith');
+		    expect(profile.displayName).toEqual('Jane Smith');
+		    expect(profile.issuerDid).toEqual('did:issuer:456');
+		    expect(profile.organizations).toEqual([{
+			id: 'org-456',
+			name: 'Other Org',
+			roles: [{ id: 'orgAdmin', name: 'orgAdmin' }]
+		    }]);
+		});
+
+		userStrategy.setProfileParams(null, vcClaims, 'lear-token-2', 'lear-refresh-2');
+		userStrategy.loginComplete();
+	    });
+
+	    it('should fall back to OIDC profile when claims have no VC structure', async () => {
+		const oidcClaims = {
+		    sub: 'user-sub-123',
+		    preferred_username: 'testuser',
+		    name: 'Test User'
+		};
+
+		const userStrategy = await builderToTest.buildStrategy((accessToken, refreshToken, profile, cbDone) => {
+		    expect(profile.id).toEqual('user-sub-123');
+		    expect(profile.username).toEqual('testuser');
+		    expect(profile.displayName).toEqual('Test User');
+		    expect(profile.roles).toEqual([{ name: 'seller', id: 'seller' }]);
+		    expect(profile.organizations).toEqual([]);
+		});
+
+		userStrategy.setProfileParams(null, oidcClaims, 'oidc-token', 'oidc-refresh');
+		userStrategy.loginComplete();
+	    });
 	});
 
 	it('should return specified scope', () => {


### PR DESCRIPTION
## Summary

  This MR includes two improvements to the OpenID Connect authentication flow with Verifiable Credentials (VC) support:

  1. Add DSP enable flag (BAE_LP_DSP_ENABLED)

  Introduces a new `config.dspEnabled` boolean (default `false`) controlled by the `BAE_LP_DSP_ENABLED` environment variable. The flag is also exposed via the /config endpoint so the frontend can consume it.

  2. Fix OpenID Connect profile building with VC

  - Fixes VerifiableCredential parsing to handle JWTs whose payload contains a credentialSubject directly (previously only verifiableCredential and vc wrappers were handled).
  - Moves OIDC strategy to use tokenSet.claims() instead of userinfo for profile extraction, enabling VC data embedded in the ID token to be picked up correctly.
  - Adds a custom userProfile function that verifies the access token signature using the issuer's JWKS and extracts the profile from its payload.
  - Adds optional nonce support in the OIDC flow via the BAE_LP_OAUTH2_NONCE environment variable (default false).

 ### Environment variables added

| Variable | Default | Description |
|---|---|---|
| `BAE_LP_DSP_ENABLED` | `false` | Enables DSP features in the frontend |
| `BAE_LP_OAUTH2_NONCE` | `false` | Enables nonce generation in the OIDC authorization request |